### PR TITLE
Rename dippy to mpakt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # README
 
-README for the DIPpy app
+README for the MPAKT. app
 
 ## Webpacker
 
-DIPpy uses webpacker, which may need you to install a bunch of stuff with yarn, for more information see
+MPAKT. uses webpacker, which may need you to install a bunch of stuff with yarn, for more information see
 https://www.botreetechnologies.com/blog/introducing-jquery-in-rails-6-using-webpacker
 
 ## Test

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>DIPpy</title>
+    <title>MPAKT.</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width">

--- a/app/views/policies/cookies.html.erb
+++ b/app/views/policies/cookies.html.erb
@@ -20,10 +20,10 @@
       <th><%= t(".ct_more") %></th>
     </thead>
     <tr>
-      <td><%= t(".ct_dippy") %></td>
-      <td><%= t(".ct_dippy_type") %></td>
-      <td><%= t(".ct_dippy_for") %></td>
-      <td><%= t(".ct_dippy_more") %></td>
+      <td><%= t(".ct_mpakt") %></td>
+      <td><%= t(".ct_mpakt_type") %></td>
+      <td><%= t(".ct_mpakt_for") %></td>
+      <td><%= t(".ct_mpakt_more") %></td>
     </tr>
     <tr>
       <td><%= t(".ct_cookies") %></td>

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Dippy
+module Mpakt
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: dippy_production
+  channel_prefix: mpakt_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,15 +14,15 @@ default: &default
 
 development:
   <<: *default
-  database: dippy_development
+  database: mpakt_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: dippy_test
+  database: mpakt_test
 
 production:
   <<: *default
-  database: dippy
+  database: mpakt

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "dippy_#{Rails.env}"
+  # config.active_job.queue_name_prefix = "mpakt_#{Rails.env}"
 
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -79,7 +79,7 @@ Thredded.layout = 'thredded/application'
 # ==> Email Configuration
 # Email "From:" field will use the following
 # (this is also used as the "To" address for both email notifcations, as all the recipients are on bcc)
-Thredded.email_from = 'dippy.moderator@gmail.com'
+Thredded.email_from = 'mpakt.moderator@gmail.com'
 
 # Emails going out will prefix the "Subject:" with the following string
 # Thredded.email_outgoing_prefix = '[My Forum] '

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -61,7 +61,7 @@ en:
         private: "Your email address is held securely and will not be shared"
         public: "Your short name is public and will be seen by other users, we suggest that you use a handle which does not identify the real you"
     sessions:
-      signed_in: "Welcome back to DIPpy"
+      signed_in: "Welcome back to MPAKT."
       signed_out: "You have signed out, please close your tab or browser"
       already_signed_out: "You have signed out, please close your tab or browser"
       new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,11 +3,11 @@ en:
   welcome:
     index:
       subtitle: "Diversity, Inclusion and Privilege"
-      safe: "DIPpy is a moderated safe space for anonymous conversations about diversity, inclusion, and privilege.
+      safe: "MPAKT. is a moderated safe space for anonymous conversations about diversity, inclusion, and privilege.
       It's built and moderated by volunteers, and we do not make any financial revenue from this site."
       welcome: "Please make everyone feel welcome here, whatever their privilege."
       calculator_html: "Calculate your privilege score with the <a class='link' href='/privileges'>privilege calculator</a>"
-      why_html: "Why did we build DIPpy and what will you find here? <a class='link' href='/goals'>Find out more</a>"
+      why_html: "Why did we build MPAKT. and what will you find here? <a class='link' href='/goals'>Find out more</a>"
 
   success:
     create: "Created %{name}"
@@ -16,7 +16,7 @@ en:
 
   layouts:
     header:
-      title: "DIPpy"
+      title: "MPAKT."
       privilege: "My privilege"
       exit: "Sign out"
       sign_in: "Sign in"

--- a/config/locales/policy.yml
+++ b/config/locales/policy.yml
@@ -21,10 +21,10 @@ en:
       ct_purpose: "Purpose"
       ct_type: "Type"
       ct_more: "More information"
-      ct_dippy: "_dippy_session"
-      ct_dippy_type: "Strictly Necessary"
-      ct_dippy_for: "To authenticate the user in the secure area of DIPpy, this is a strictly necessary cookie."
-      ct_dippy_more: "Temporary cookie, expires at the end of the session"
+      ct_mpakt: "_mpakt_session"
+      ct_mpakt_type: "Strictly Necessary"
+      ct_mpakt_for: "To authenticate the user in the secure area of MPAKT., this is a strictly necessary cookie."
+      ct_mpakt_more: "Temporary cookie, expires at the end of the session"
       ct_cookies: "cookie_eu_consented"
       ct_cookies_type: "Functionality"
       ct_cookies_for: "Stores the information that you have accepted our cookies. Does not hold any other information."
@@ -32,26 +32,26 @@ en:
 
       note: "Please note that third parties (including, for example, advertising networks and providers of external
       services like web traffic analysis services) may also use cookies, and we have no control over these cookies.
-      Your browser tracks cookies from all your open tabs and you may see cookies that are not relevant to DIPpy"
+      Your browser tracks cookies from all your open tabs and you may see cookies that are not relevant to MPAKT."
       block: "You block cookies by activating the setting on your browser that allows you to refuse the setting of all
       or some cookies. However, if you use your browser settings to block all cookies (including essential cookies) you
       may not be able to access all or parts of our site."
 
     ts_and_cs:
-      title: "DIPpy Terms and Conditions of Use"
+      title: "MPAKT. Terms and Conditions of Use"
       summary_title: "Summary"
-      summary: "DIPpy is a not-for-profit moderated safe space for anonymous conversations about diversity, inclusion, and
-      privilege. We intend your experience of DIPpy to be smooth and safe. We work with our cloud provider
+      summary: "MPAKT. is a not-for-profit moderated safe space for anonymous conversations about diversity, inclusion, and
+      privilege. We intend your experience of MPAKT. to be smooth and safe. We work with our cloud provider
       to keep the site alive, look after your data, protect you from data loss, and protect you from data breaches.
       If we discover any part of our site or responsibilities fail to meet our standards, we will post information
       on the site as quickly as possible. Many users visit this site anonymously. We only notify users of a
       security breach if you have signed in and provided us with your contact details, for example an email address."
-      summary_1: "We expect you will be friendly when you use DIPpy and respect other users. If you sign in, keep your
+      summary_1: "We expect you will be friendly when you use MPAKT. and respect other users. If you sign in, keep your
       password safe."
       legal_title: "Legal terms and conditions"
       legal_html: "By using our website, you acknowledge that you have read, understood and accept these Terms and Conditions
       of Use and that you agree to be bound by them. You also accept our <a href='privacy;' target='_blank'>Data Privacy
-      Policy</a>. If you do not agree to these terms of use, you must stop using our website. DIPpy is a not-for-profit
+      Policy</a>. If you do not agree to these terms of use, you must stop using our website. MPAKT. is a not-for-profit
       website operated by volunteers (referred to as 'us', 'we' or 'our')."
       third_party: "Third Parties and Links from our Website to Other Websites"
       third_party_para1: "Our website may contain links to other websites and resources provided by third parties –
@@ -79,42 +79,42 @@ en:
       ip_para1: "By using the website you agree to refrain from copying, downloading, transmitting, reproducing,
       printing, or exploiting for commercial purpose(s) any material contained within the website."
       limitation: "Limitation of Liability"
-      limitation_para1: "DIPpy will not, under any circumstances, be liable for indirect, special, or
+      limitation_para1: "MPAKT. will not, under any circumstances, be liable for indirect, special, or
       consequential damages, including any loss of business, revenue, profits or data in relation to your use of the
       website."
       limitation_para2: "Nothing within these Terms and Conditions of Use will operate to include any liability for
-      death or personal injury arising as result of the negligence of the volunteers who maintain DIPpy"
+      death or personal injury arising as result of the negligence of the volunteers who maintain MPAKT."
       law: "Governing Law and Jurisdiction"
       law_para: "These Terms and Conditions of Use will be governed by law and any user of the website agrees to be
       bound exclusively by the jurisdiction of relevant courts, should any dispute or claim arise from, or in connection
       with, them or their subject matter or formation (including non-contractual disputes or claims)."
       about_us: "About Us"
-      about_us_para: "The DIPpy site is built and maintained by volunteers who may be found anywhere in the world. The
-      users of DIPpy are also global. We ask you to respect all volunteers and users of DIPpy."
+      about_us_para: "The MPAKT. site is built and maintained by volunteers who may be found anywhere in the world. The
+      users of MPAKT. are also global. We ask you to respect all volunteers and users of MPAKT.."
       anonymous: "Anonymous"
-      anonymous_para: "DIPpy is an anonymous site"
+      anonymous_para: "MPAKT. is an anonymous site"
       anonymous_para_1: "Most parts of the site are fully anonymous, and do not require you to tell us anything about yourself
-      in order to visit and read content in DIPpy"
-      anonymous_para_2: "The DIPpy forum is public-anonymous. In order to contribute the forum, you need to register, and you
+      in order to visit and read content in MPAKT."
+      anonymous_para_2: "The MPAKT. forum is public-anonymous. In order to contribute the forum, you need to register, and you
       must tell us an email address. This means that when you return to the site, you can see your own posting history.
       We do not share this email address with other users."
       anonymous_para_3: "We will not share your email address with any third parties, for commercial or any other reasons,
       except if requested with a recognised court order. When you provide your email address, we use it internally to
       identify you uniquely, and so that we can send you password reset information if you forget your password. We
       do not share your email address with other users."
-      anonymous_para_4: "When you sign up for DIPpy, you create a short user name, choose this carefully, it should not identify
+      anonymous_para_4: "When you sign up for MPAKT., you create a short user name, choose this carefully, it should not identify
       you. This is the name which other users will see. In this way, when users see your posts, they can not find out more
       information about you. Do not tell anyone what your short user name is."
       age: "Age"
-      age_1: "This site is intended for adults, and we recommend that children under 16 do not visit this site or register with DIPpy."
+      age_1: "This site is intended for adults, and we recommend that children under 16 do not visit this site or register with MPAKT.."
 
       moderated: "Moderated"
-      moderated_para: "DIPpy is a moderated site."
+      moderated_para: "MPAKT. is a moderated site."
       moderated_para_1: "This site is intended to be a safe space, and to keep your details private. But with anonymity
       comes the risk that users will indulge in inappropriate or harrassing behaviour."
-      moderated_para_2: "Some DIPpy volunteers administer the site, and are able to remove content if it is considered
+      moderated_para_2: "Some MPAKT. volunteers administer the site, and are able to remove content if it is considered
       harmful."
-      moderated_para_3: "The DIPpy volunteers have absolute discretion over what content is used, how it is managed, where
+      moderated_para_3: "The MPAKT. volunteers have absolute discretion over what content is used, how it is managed, where
       it is posted, and to move or delete any content at any time."
       moderated_para_4: "We don't intend this moderation to be onerous for us or frustrating for you: we will only use
                          moderation to remove your content if we believe it is harmful to the users of this site, or to
@@ -129,15 +129,15 @@ en:
       harmful_content_6: "objectionable"
       harmful_content_7: "violate the legal rights of others"
       harmful_content_8: "could damage a computer"
-      free_para: "DIPpy is a not-for-profit site, we may remove content that appears to include any form of advertisement."
+      free_para: "MPAKT. is a not-for-profit site, we may remove content that appears to include any form of advertisement."
 
     privacy:
       title: "Privacy Policy"
-      us_title_html: "DIPpy is committed to protecting and respecting your privacy."
+      us_title_html: "MPAKT. is committed to protecting and respecting your privacy."
       us_1_html: "This policy, together with our <a target='_blank' href='/ts_and_cs'>Terms and Conditions</a> sets out how
-      we process your data. Please read it carefully. By visiting DIPpy you accept and consent to the practices described in this policy."
+      we process your data. Please read it carefully. By visiting MPAKT. you accept and consent to the practices described in this policy."
       information_title: "Information we collect from you"
-      information_1: "We collect and process information about you that you give us by registering with DIPpy, or when you
+      information_1: "We collect and process information about you that you give us by registering with MPAKT., or when you
        send us e-mail. It includes information you provide when you participate in discussions on forums, and when you report a
        problem with our site. The information you give us may include your name, e-mail address, and any other information you
        choose to share."
@@ -147,7 +147,7 @@ en:
       <a href='/cookies' target='_blank'>Cookie policy</a>"
       disclosure_title: "Disclosure of your information"
       disclosure: "We only share your information if we are under a duty to disclose or share your personal data in order to
-      comply with any legal obligation, or to protect the safety of DIPpy users and volunteers."
+      comply with any legal obligation, or to protect the safety of MPAKT. users and volunteers."
       store_title: "Where we store your personal data"
       store_1: "The data that we collect from you is transferred to and stored at our cloud provider and their
       data centres. By submitting your personal data, you agree to this transfer, storing or processing.
@@ -162,14 +162,14 @@ en:
       access_1: "You may ask us to let you know what information we hold about you."
       changes_title: "Changes to our privacy policy"
       changes_1: "Any changes we make to our privacy policy in the future will be posted on this page and, if
-       there are major changes, we may also announce them elsewhere in the DIPpy website. We usually do not send
+       there are major changes, we may also announce them elsewhere in the MPAKT. website. We usually do not send
        emails to users, partly because not all users share their email addresses with us. Please check back frequently
        to see any updates or changes to our privacy policy."
       contact_title: "Contact"
-      contact_1: "Contact us by email at dippy.moderator@gmail.com"
+      contact_1: "Contact us by email at mpakt.moderator@gmail.com"
 
     goals:
-      why: "Why did we build DIPpy? What will you find here?"
+      why: "Why did we build MPAKT.? What will you find here?"
       safe_space: "Safe space"
       safe_space_1: "As members of several diversity groups on Facebook, we have seen posts that resonate with the group,
       who follow up with a lot of comments around 'me too' or 'how brave you are'. It seems that a lot of us are too scared
@@ -180,7 +180,7 @@ en:
       But this has the opposite challenge: a busy community has so much traffic that most of it scrolls
       out of sight before we can keep up with it, and the newish threading feature doesn't seem to provide a
       good solution."
-      safe_space_3: "For all these reasons, we are building DIPpy with an anonymous, moderated forum where you can discuss diversity,
+      safe_space_3: "For all these reasons, we are building MPAKT. with an anonymous, moderated forum where you can discuss diversity,
       inclusion, and privilege. The forum is not ready yet, it's currently being built, please have patience, we are a volunteer
       organisation."
       more_diversity: "More diversity"
@@ -215,4 +215,4 @@ en:
       a database of diversity, with primary focus on how it affects your working life. For the moment it has four key areas,
       equally weighted: the areas and weights may change in future as we collect data about privilege and its impact on your
       working life, so please do come back and check your privilege score again."
-      thank_you: "Thank you for visiting DIPpy, and for reading to the end. We hope you enjoy your visit!"
+      thank_you: "Thank you for visiting MPAKT., and for reading to the end. We hope you enjoy your visit!"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dippy",
+  "name": "mpakt",
   "private": true,
   "dependencies": {
     "@rails/ujs": "^6.0.0",

--- a/spec/features/blog_spec.rb
+++ b/spec/features/blog_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Blog" do
 
   context "As an admin" do
-    let(:admin) { User.create(email: "blog_admin@dippy.com", password: "123456", short_name: "blog_admin", volunteer: true, admin: true, last_sign_in_at: Time.zone.now) }
+    let(:admin) { User.create(email: "blog_admin@mpakt.com", password: "123456", short_name: "blog_admin", volunteer: true, admin: true, last_sign_in_at: Time.zone.now) }
 
     scenario "I can create and manage blog posts" do
       login_as admin
@@ -84,7 +84,7 @@ RSpec.feature "Blog" do
   end
 
   context "As an user" do
-    let(:user) { User.create(email: "blog@dippy.com", password: "123456", short_name: "blog", last_sign_in_at: Time.zone.now) }
+    let(:user) { User.create(email: "blog@mpakt.com", password: "123456", short_name: "blog", last_sign_in_at: Time.zone.now) }
 
     scenario "I can not edit blog posts" do
       login_as user

--- a/spec/features/policy_spec.rb
+++ b/spec/features/policy_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Ts and Cs" do
         exclude_keys: [:us_1_html, :cookies_1_html]
       )
 
-      expect(page).to have_content "This policy, together with our Terms and Conditions sets out how we process your data. Please read it carefully. By visiting DIPpy you accept and consent to the practices described in this policy."
+      expect(page).to have_content "This policy, together with our Terms and Conditions sets out how we process your data. Please read it carefully. By visiting MPAKT. you accept and consent to the practices described in this policy."
       expect(page).to have_content "Our website uses cookies to distinguish you from other users of our website. This helps us to provide a good experience when you browse our website. For detailed information on the cookies we use see our Cookie policy"
     end
   end

--- a/spec/features/privilege_spec.rb
+++ b/spec/features/privilege_spec.rb
@@ -163,7 +163,7 @@ RSpec.feature "Privilege" do
   end
 
   context "As an authenticated user" do
-    let(:user) { User.create(email: "user@dippy.com", password: "123456", short_name: "user", last_sign_in_at: Time.zone.now) }
+    let(:user) { User.create(email: "user@mpakt.com", password: "123456", short_name: "user", last_sign_in_at: Time.zone.now) }
     scenario "I can not see the salary summary" do
       login_as user
 
@@ -182,7 +182,7 @@ RSpec.feature "Privilege" do
   end
 
   context "As an authenticated admin" do
-    let(:admin) { User.create(email: "admin@dippy.com", password: "123456", short_name: "admin", volunteer: true, admin: true, last_sign_in_at: Time.zone.now) }
+    let(:admin) { User.create(email: "admin@mpakt.com", password: "123456", short_name: "admin", volunteer: true, admin: true, last_sign_in_at: Time.zone.now) }
 
     scenario "I can see the salary summary" do
       privilege = Privilege.create(salary: 5)

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "User" do
       end
 
       within ".new_user" do
-        fill_in :user_email, with: "new_user@dippy.com"
+        fill_in :user_email, with: "new_user@mpakt.com"
         fill_in :user_short_name, with: "shorty"
         fill_in :user_password, with: "123456"
         fill_in :user_password_confirmation, with: "123456"
@@ -44,7 +44,7 @@ RSpec.feature "User" do
       end
 
       within ".new_user" do
-        fill_in :user_email, with: "new_user@dippy.com"
+        fill_in :user_email, with: "new_user@mpakt.com"
         fill_in :user_password, with: "123456"
 
         click_on I18n.t("devise.sessions.new.sign_in")
@@ -57,7 +57,7 @@ RSpec.feature "User" do
   end
 
   context "As a user" do
-    let(:user) { User.create(email: "user@dippy.com", password: "123456", short_name: "user", last_sign_in_at: Time.zone.now) }
+    let(:user) { User.create(email: "user@mpakt.com", password: "123456", short_name: "user", last_sign_in_at: Time.zone.now) }
 
     scenario "I can edit my profile" do
       login_as user
@@ -81,7 +81,7 @@ RSpec.feature "User" do
       end
 
       within ".flash" do
-        notice = I18n.t("users.update.success", email: "user@dippy.com")
+        notice = I18n.t("users.update.success", email: "user@mpakt.com")
         expect(page).to have_content notice
       end
 
@@ -94,7 +94,7 @@ RSpec.feature "User" do
     scenario "I can not manage users, moderate or administer the forum" do
       login_as user
 
-      user = User.create(email: "no_access_user@dippy.com", password: "123456", short_name: "user", last_sign_in_at: Time.zone.now)
+      user = User.create(email: "no_access_user@mpakt.com", password: "123456", short_name: "user", last_sign_in_at: Time.zone.now)
       Thredded::Messageboard.create!(name: "Test board")
       visit "/"
 
@@ -127,12 +127,12 @@ RSpec.feature "User" do
   end
 
   context "As a moderator" do
-    let(:moderator) { User.create(email: "moderator@dippy.com", password: "123456", short_name: "moderator", last_sign_in_at: Time.zone.now, volunteer: true) }
+    let(:moderator) { User.create(email: "moderator@mpakt.com", password: "123456", short_name: "moderator", last_sign_in_at: Time.zone.now, volunteer: true) }
 
     scenario "I can not manage users or forums, I can moderate posts" do
       login_as moderator
 
-      user = User.create!(email: "another_user@dippy.com", password: "123456", short_name: "user", last_sign_in_at: Time.zone.now)
+      user = User.create!(email: "another_user@mpakt.com", password: "123456", short_name: "user", last_sign_in_at: Time.zone.now)
       Thredded::Messageboard.create!(name: "Test board")
       visit "/"
 
@@ -165,10 +165,10 @@ RSpec.feature "User" do
   end
 
   context "As an admin" do
-    let(:admin) { User.create(email: "admin@dippy.com", password: "123456", short_name: "admin", volunteer: true, admin: true, last_sign_in_at: Time.zone.now) }
+    let(:admin) { User.create(email: "admin@mpakt.com", password: "123456", short_name: "admin", volunteer: true, admin: true, last_sign_in_at: Time.zone.now) }
 
     scenario "I can manage other users" do
-      user = User.create(email: "other_user@dippy.com", password: "123456", short_name: "user", last_sign_in_at: Time.zone.now)
+      user = User.create(email: "other_user@mpakt.com", password: "123456", short_name: "user", last_sign_in_at: Time.zone.now)
 
       login_as admin
       visit "/"
@@ -181,8 +181,8 @@ RSpec.feature "User" do
       within ".users" do
         rows = page.all("tr")
         expect(rows.count).to eq 3
-        expect(rows[1]).to have_content "admin@dippy.com admin #{today}"
-        expect(rows[2]).to have_content "other_user@dippy.com user #{today}"
+        expect(rows[1]).to have_content "admin@mpakt.com admin #{today}"
+        expect(rows[2]).to have_content "other_user@mpakt.com user #{today}"
       end
 
       within ".user-#{admin.id}" do


### PR DESCRIPTION
Rename dippy to mpakt - remove "dippy" wherever it's found

WARNING: DB rename, so the db will need to be recreated when this is deployed