### PR TITLE
Disable gravatar

### DIFF
--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -30,7 +30,7 @@ Thredded.user_path = ->(user) {
 Thredded.current_user_method = :"current_#{Thredded.user_class_name.demodulize.underscore}"
 
 # User avatar URL. rb-gravatar gem is used by default:
-Thredded.avatar_url = ->(user) { Gravatar.src(user.email, 156, 'mm') }
+# Thredded.avatar_url = ->(user) { Gravatar.src(user.email, 156, 'mm') }
 
 # ==> Permissions Configuration
 # By default, thredded uses a simple permission model, where all the users can post to all message boards,


### PR DESCRIPTION
In automatic config, thredded had enabled gravatar. We don't want this, because it might compromise anonymity, so removing!
